### PR TITLE
feat: Add fee configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'devise'
 gem 'devise-jwt'
 gem 'jsonapi-serializer'
 
+# I18n
+gem 'i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ DEPENDENCIES
   devise-jwt
   dotenv-rails
   factory_bot_rails (~> 6.1.0)
+  i18n
   jsonapi-serializer
   pg (~> 1.1)
   puma (>= 5.0)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 * Deployment instructions
 
+* Flow
+
 ## Database creation
 
 Once you have the repository on your computer, follow these steps to configure the project:
@@ -24,3 +26,24 @@ rails db:migrate
 ## Deployment instructions
 
 To start the project, run the command `rails s`
+
+## Flow
+
+First we will create a user from the /signup endpoint. From which we can create it without passing anything about the fee configuration, and the default one will be created with everything activated and 1% fee for trades and payments. Or if not, you can pass the attributes that you see necessary within the object (it is not mandatory to pass all 4, if you want to leave any of them as they are by default, they can be left that way). I leave a sample of the payload:
+
+```
+{
+    "user": {
+        "email": "test01@test.com",
+        "password": "123456",
+        "fee_configuration": {
+            "trades": true,
+            "trades_percentage": 11,
+            "payments": false,
+            "payments_percentage": 5
+        }
+    }
+}
+```
+
+Once we have registered, within the header it will return the authorization with which we will have to interact with the back to be able to continue carrying out the following steps.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::API
   include RackSessionFix
+  include ApiErrorHandler
 end

--- a/app/controllers/concerns/api_error_handler.rb
+++ b/app/controllers/concerns/api_error_handler.rb
@@ -1,0 +1,17 @@
+module ApiErrorHandler
+  extend ActiveSupport::Concern
+
+  def print_error(error_code, details, status)
+    render json: {
+      status: 'error',
+      status_code: status,
+      error: {
+        code: error_code,
+        message: I18n.t("api.errors.#{error_code}.title"),
+        details: details,
+        path: request.path,
+        timestamp: Time.now
+      }
+    }, status: status
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,22 +4,35 @@ class Users::RegistrationsController < Devise::RegistrationsController
   include RackSessionFix
   respond_to :json
 
+  def create
+    ActiveRecord::Base.transaction do
+      super
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    print_error('invalid_record', e.message, 422)
+  end
+
   private
 
   def respond_with(resource, _opts = {})
     if request.method == "POST" && resource.persisted?
+      update_fee_configuration(resource)
       render json: {
         status: {code: 200, message: "Signed up sucessfully."},
         data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
       }, status: :ok
-    elsif request.method == "DELETE"
-      render json: {
-        status: { code: 200, message: "Account deleted successfully."}
-      }, status: :ok
     else
-      render json: {
-        status: {code: 422, message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}"}
-      }, status: :unprocessable_entity
+      print_error('invalid_record', resource.errors.full_messages.to_sentence, 422)
     end
+  end
+
+  def update_fee_configuration(resource)
+    return unless fee_configuration_params
+
+    resource.fee_configuration.update!(fee_configuration_params)
+  end
+
+  def fee_configuration_params
+    params['user']['fee_configuration']&.permit(:payments, :payments_percentage, :trades, :trades_percentage)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,7 +13,7 @@ class Users::SessionsController < Devise::SessionsController
         data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
       }, status: :ok
     else
-      render json: { status: 401, message: 'Incorrect credentials' }, status: :unauthorized
+      print_error('unauthorized', 'Incorrect credentials', 401)
     end
   end
 
@@ -24,10 +24,7 @@ class Users::SessionsController < Devise::SessionsController
         message: "logged out successfully"
       }, status: :ok
     else
-      render json: {
-        status: 401,
-        message: "Couldn't find an active session."
-      }, status: :unauthorized
+      print_error('unauthorized', 'Incorrect credentials', 401)
     end
   end
 end

--- a/app/models/fee_configuration.rb
+++ b/app/models/fee_configuration.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: fee_configurations
+#
+#  id                  :bigint           not null, primary key
+#  payments            :boolean          default(TRUE), not null
+#  payments_percentage :float            default(1.0)
+#  trades              :boolean          default(TRUE), not null
+#  trades_percentage   :float            default(1.0)
+#  uuid                :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_fee_configurations_on_user_id  (user_id)
+#
+class FeeConfiguration < ApplicationRecord
+  belongs_to :user
+
+  before_create :generate_uid
+
+  validates :payments_percentage, :numericality => { :greater_than_or_equal_to => 0, :less_than_or_equal_to => 100 }
+  validates :trades_percentage, :numericality => { :greater_than_or_equal_to => 0, :less_than_or_equal_to => 100 }
+
+  def generate_uid
+    self.uuid = SecureRandom.uuid
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,9 @@ class User < ApplicationRecord
          :jwt_authenticatable, jwt_revocation_strategy: self
 
   before_create :generate_uuid
+  after_create :create_fee_configuration
+
+  has_one :fee_configuration
 
   def generate_uuid
     self.uuid = SecureRandom.uuid

--- a/app/serializers/fee_configuration_serializer.rb
+++ b/app/serializers/fee_configuration_serializer.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: fee_configurations
+#
+#  id                  :bigint           not null, primary key
+#  payments            :boolean          default(TRUE), not null
+#  payments_percentage :float            default(1.0)
+#  trades              :boolean          default(TRUE), not null
+#  trades_percentage   :float            default(1.0)
+#  uuid                :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_fee_configurations_on_user_id  (user_id)
+#
+class FeeConfigurationSerializer
+  include JSONAPI::Serializer
+  set_id :uuid
+  attributes :trades, :trades_percentage, :payments, :payments_percentage
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -24,5 +24,5 @@ class UserSerializer
   set_id :uuid
   attributes :email, :created_at
 
-  has_one :fee_configuration, serializer: FeeConfigurationSerializer
+  has_one :fee_configuration, serializer: FeeConfigurationSerializer, id_method_name: :uuid
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  jti                    :string           not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  uuid                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_jti                   (jti) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class UserSerializer
   include JSONAPI::Serializer
   set_id :uuid
   attributes :email, :created_at
+
+  has_one :fee_configuration, serializer: FeeConfigurationSerializer
 end

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,2 @@
+I18n.load_path += Dir[Rails.root.join('config', 'locales', '*.{rb,yml}')]
+I18n.default_locale = :en

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,9 @@
 
 en:
   hello: "Hello world"
+  api:
+    errors:
+      invalid_record:
+        title: This record does not meet the necessary requirements to be saved
+        suggestion: Please check the documentation and enter the correct parameters
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,4 +34,7 @@ en:
       invalid_record:
         title: This record does not meet the necessary requirements to be saved
         suggestion: Please check the documentation and enter the correct parameters
+      unauthorized:
+        title: Authentication is required to access this resource
+        suggestion: Please check that the credentials are correct
 

--- a/db/migrate/20240426133424_create_fee_configuration.rb
+++ b/db/migrate/20240426133424_create_fee_configuration.rb
@@ -1,0 +1,14 @@
+class CreateFeeConfiguration < ActiveRecord::Migration[7.1]
+  def change
+    create_table :fee_configurations do |t|
+      t.string :uuid, null: false
+      t.boolean :trades, default: true, null: false
+      t.float :trades_percentage, default: 1
+      t.boolean :payments, default: true, null: false
+      t.float :payments_percentage, default: 1
+      t.references :user, index: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_25_160554) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_26_133424) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "fee_configurations", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.boolean "trades", default: true, null: false
+    t.float "trades_percentage", default: 1.0
+    t.boolean "payments", default: true, null: false
+    t.float "payments_percentage", default: 1.0
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_fee_configurations_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/docs/dev/decisions.md
+++ b/docs/dev/decisions.md
@@ -10,6 +10,8 @@
 
 * Simplecov
 
+* I18n
+
 ## Annotate gem
 
 Gem used to be able to write down all the attributes of a model in the file itself, with its characteristics. To run it you just have to run the following command: `bundle exec annotate`. But when you perform a migration it makes these notes automatically.
@@ -29,3 +31,7 @@ Factory Bot helps us generate models with test data without having to create the
 ## Simplecov
 
 Gem that allows us to see what percentage of code we have tested. Simply by running the tests as always, we will get the result in the end.
+
+## I18n
+
+The I18n library has been added, since it helps a lot with error control and handling it by code and for future translations if necessary.

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -17,5 +17,26 @@ RSpec.describe Users::RegistrationsController, type: :controller do
 
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it 'with invalid fee configuration' do
+      post :create, params: { user: { email: 'test@test.com', password: '123456', fee_configuration: { trades: true, trades_percentage: 110 } } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'with valid fee configuration' do
+      post :create, params: { user: { email: 'test@test.com', password: '123456', fee_configuration: { trades: true, trades_percentage: 20 } } }
+
+      expect(response).to have_http_status(:ok)
+      expect(User.last.fee_configuration.trades_percentage).to eq 20
+    end
+
+    it 'register with the same email that other user' do
+      user = create(:user)
+
+      post :create, params: { user: { email: user.email, password: '123456' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
   end
 end

--- a/spec/factories/fee_percentage.rb
+++ b/spec/factories/fee_percentage.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  jti                    :string           not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  uuid                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_jti                   (jti) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+FactoryBot.define do
+  factory :fee_percentage do
+    payments { true }
+    payments_percentage { 1 }
+    trades { true }
+    trades_percentage { 1 }
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  jti                    :string           not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  uuid                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_jti                   (jti) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     email { 'test@test.com' }

--- a/spec/models/fee_configuration_spec.rb
+++ b/spec/models/fee_configuration_spec.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: fee_configurations
+#
+#  id                  :bigint           not null, primary key
+#  payments            :boolean          default(TRUE), not null
+#  payments_percentage :float            default(1.0)
+#  trades              :boolean          default(TRUE), not null
+#  trades_percentage   :float            default(1.0)
+#  uuid                :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  user_id             :bigint           not null
+#
+# Indexes
+#
+#  index_fee_configurations_on_user_id  (user_id)
+#
+require 'rails_helper'
+
+RSpec.describe FeeConfiguration, type: :model do
+  let(:user) { create(:user) }
+  context 'validations' do
+    it "is not valid with negative payments percentage" do
+      fee_configuration = FeeConfiguration.new(user_id: user.id, payments: true, payments_percentage: -5)
+      expect(fee_configuration).to_not be_valid
+    end
+
+    it "is not valid with trades percentage greater than 0" do
+      fee_configuration = FeeConfiguration.new(user_id: user.id, trades: true, trades_percentage: 110)
+      expect(fee_configuration).to_not be_valid
+    end
+
+    it 'is valid with correct parameters' do
+      fee_configuration = FeeConfiguration.new(user_id: user.id, trades: true, trades_percentage: 10)
+      expect(fee_configuration).to be_valid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  jti                    :string           not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  uuid                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_jti                   (jti) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe User, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,4 +51,16 @@ RSpec.describe User, type: :model do
       expect(@user.uuid).not_to be_empty
     end
   end
+
+  context 'after_create actions' do
+    before do
+      @user = User.new(email: 'test@test.com', password: '123456')
+    end
+
+    it 'when create the user, the model generate a uuid' do
+      @user.save
+
+      expect(@user.fee_configuration).to eq FeeConfiguration.last
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses several cases linked to the logic of configuring the fee per user. First I explain how this logic works:

* If a user registers without passing the necessary parameters to create the fee, it will be created with the standard data, everything activated and 1% for both cases.
* If the user passes some data, that fee data will be replaced. If in any case the percentages are less than 0 or greater than 100, it will fail with a rescue and the error will be displayed on the console.

After this I comment that the I18n library has been added, since it helps a lot with error control and handling it by code.

An ApiErrorHandler has been created to have errors handled from the same place.